### PR TITLE
fix(format.bm_bitmap()): Function 'fg' and 'bg' arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bittermelon
 Type: Package
 Title: Bitmap Tools
-Version: 2.0.3-0
+Version: 2.0.3-3
 Authors@R: c(person("Trevor L.", "Davis", role = c("aut", "cre"),
                     email = "trevor.l.davis@gmail.com",
                     comment = c(ORCID = "0000-0001-6341-4639")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,20 @@
 bittermelon 2.0.3 (development)
 ===============================
 
+New features
+------------
+
 * New `as_bm_bitmap()` / `as_bm_pixmap()` class methods:
 
   * `as_bm_bitmap.lofi-matrix()` / `as_bm_pixmap.lofi-matrix()` (from `{lofifonts}`)
+
+Bug fixes and minor improvements
+--------------------------------
+
+* The `bg` and `fg` arguments of `format.bm_bitmap()` and `print.bm_bitmap()`
+  now accept a (single) `{cli}` ANSI style function
+  in addition to lists of `{cli}` ANSI style functions
+  and character vectors of R color strings.
 
 bittermelon 2.0.2
 =================

--- a/R/print.bm_bitmap.R
+++ b/R/print.bm_bitmap.R
@@ -87,6 +87,12 @@ format.bm_bitmap <- function(x, ...,
     n <- max(x) + 1L
     px <- rep_len(px, n)
     if (!isFALSE(fg)) {
+        if (is.function(fg)) {
+            fg <- list(fg)
+        # Avoid {cli} converting to function if color string in `cli:::ansi_builtin_styles()`
+        } else if (is.character(fg)) {
+            fg <- col2hex(fg)
+        }
         fgl <- lapply(fg, function(col) cli::make_ansi_style(col))
         if (length(fgl) == 1) {
             fgl <- rep_len(fgl, n)
@@ -98,8 +104,12 @@ format.bm_bitmap <- function(x, ...,
     }
     if (!isFALSE(bg)) {
 
-        # Avoid {cli} converting to ANSI style function if color string in `cli:::ansi_builtin_styles()`
-        if (is.character(bg)) bg <- col2hex(bg)
+        if (is.function(bg)) { 
+            bg <- list(bg)
+        # Avoid {cli} converting to function if color string in `cli:::ansi_builtin_styles()`
+        } else if (is.character(bg)) {
+            bg <- col2hex(bg)
+        }
         bgl <- lapply(bg, function(col) cli::make_ansi_style(col, bg = TRUE))
         if (length(bgl) == 1) {
             bgl <- rep_len(bgl, n)

--- a/tests/testthat/test-print.bm_bitmap.R
+++ b/tests/testthat/test-print.bm_bitmap.R
@@ -30,7 +30,7 @@ test_that("print.bm_bitmap()", {
 
     plus_space_rl <- cbind(plus_sign, space_glyph, direction = "right-to-left")
     verify_output("txt/plus_space_rl.txt", {
-        print(bm_bitmap(plus_space_rl))
+        print(bm_bitmap(plus_space_rl), fg = cli::col_none, bg = cli::bg_none)
     }, unicode = TRUE)
 
     verify_output("txt/plus_unicode_color_char.txt", {

--- a/tests/testthat/txt/plus_space_rl.txt
+++ b/tests/testthat/txt/plus_space_rl.txt
@@ -1,4 +1,4 @@
-> print(bm_bitmap(plus_space_rl))
+> print(bm_bitmap(plus_space_rl), fg = cli::col_none, bg = cli::bg_none)
 ░░░░░░░░░░░░░░░░░░
 ░░░░░░░░░░░░░░░░░░
 ░░░░░░░░░░░░░█░░░░


### PR DESCRIPTION
* The `bg` and `fg` arguments of `format.bm_bitmap()` and `print.bm_bitmap()` now accept a (single) `{cli}` ANSI style function in addition to lists of `{cli}` ANSI style functions and character vectors of R color strings.