### PR TITLE
Import raw bitmap arrays

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -19,7 +19,9 @@ tests/testthat/txt/fontr.txt
 tests/testthat/test-fontr.R
 tests/testthat/txt/lofifonts.txt
 tests/testthat/test-lofifonts.R
+tests/testthat/test-pdftools.R
 tests/testthat/txt/pixeltrix.txt
 tests/testthat/test-pixeltrix.R
 tests/testthat/txt/pixmap.txt
 tests/testthat/test-pixmap.R
+tests/testthat/test-webp.R

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bittermelon
 Type: Package
 Title: Bitmap Tools
-Version: 2.1.0-4
+Version: 2.1.0-5
 Authors@R: c(person("Trevor L.", "Davis", role = c("aut", "cre"),
                     email = "trevor.l.davis@gmail.com",
                     comment = c(ORCID = "0000-0001-6341-4639")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,9 @@ Bug fixes and minor improvements
   now accept a (single) `{cli}` ANSI style function
   in addition to lists of `{cli}` ANSI style functions
   and character vectors of R color strings.
+* `bm_downscale()` no longer returns invisibly.
+* `as_bm_bitmap.array()` / `as_bm_pixmap.array()` can now handle "raw"
+  arrays as returned by `pdftools::pdf_render_page(numeric = FALSE)` and `webp::read_webp(numeric = FALSE)` (#83).
 
 bittermelon 2.0.2
 =================

--- a/R/as_bm_bitmap.R
+++ b/R/as_bm_bitmap.R
@@ -31,7 +31,7 @@ as_bm_bitmap.array <- function(x, ...,
         as_bm_bitmap.bm_pixmap(as_bm_pixmap.matrix(flip_matrix_vertically(m)),
                                mode = mode, threshold = threshold)
     } else { # RGB or RGBA
-        as_bm_bitmap.bm_pixmap(as_bm_pixmap.raster(as.raster(x)),
+        as_bm_bitmap.bm_pixmap(as_bm_pixmap.array(x),
                                mode = mode, threshold = threshold)
     }
 }
@@ -39,7 +39,11 @@ as_bm_bitmap.array <- function(x, ...,
 #' @rdname as_bm_bitmap
 #' @export
 as_bm_bitmap.default <- function(x, ...) {
-    as_bm_bitmap.matrix(as.matrix(x))
+    # "bitmap" "rgba" array from `pdftools::pdf_render_page()`
+    if (is.array(x) && is.raw(x))
+        as_bm_bitmap.bm_pixmap(as_bm_pixmap.array(x), ...)
+    else
+        as_bm_bitmap.matrix(as.matrix(x))
 }
 
 #' @rdname as_bm_bitmap

--- a/R/as_bm_pixmap.R
+++ b/R/as_bm_pixmap.R
@@ -44,12 +44,19 @@ as_bm_pixmap <- function(x, ...) {
 #' @rdname as_bm_pixmap
 #' @export
 as_bm_pixmap.default <- function(x, ...) {
-    as_bm_pixmap.raster(grDevices::as.raster(x, ...))
+    # "bitmap" "rgba" array from `pdftools::pdf_render_page()`
+    if (is.array(x) && is.raw(x))
+        as_bm_pixmap.array(x)
+    else
+        as_bm_pixmap.raster(grDevices::as.raster(x, ...))
 }
 
 #' @rdname as_bm_pixmap
 #' @export
 as_bm_pixmap.array <- function(x, ...) {
+    if (is.raw(x)) {
+        x <- aperm(structure(as.numeric(x) / 255, dim = dim(x)))
+    }
     as_bm_pixmap.raster(grDevices::as.raster(x, ...))
 }
 

--- a/R/bm_distort.R
+++ b/R/bm_distort.R
@@ -37,7 +37,7 @@ bm_distort <- function(x, width = NULL, height = NULL, ...) {
 #' @export
 bm_downscale <- function(x, width = getOption("width"), ...) {
     if (bm_widths(x) > width)
-        x <- bm_distort(x, width = width, ...)
+        bm_distort(x, width = width, ...)
     else
         x
 }

--- a/tests/testthat/test-pdftools.R
+++ b/tests/testthat/test-pdftools.R
@@ -1,0 +1,27 @@
+test_that("`pdftools::pdf_render_page()` import works", {
+    skip_if_not_installed("pdftools")
+
+    skip_if_not_installed("withr")
+    skip_if_not(cli::is_utf8_output())
+    withr::local_options(bm_options(default = TRUE))
+
+    filename <- tempfile(fileext = ".pdf")
+    on.exit(unlink(filename))
+    pdf(filename, bg = "blue")
+    grid::grid.newpage()
+    grid::grid.text("")
+    invisible(dev.off())
+
+    array_num <- pdftools::pdf_render_page(filename, 1L, numeric = TRUE)
+    pm <- as_bm_pixmap(array_num)
+    expect_equal(pm[1L, 1L], col2hex("blue"))
+    bm <- as_bm_bitmap(array_num)
+    expect_equal(bm[1L, 1L], 1L)
+
+    skip("`pdf_render_page(numeric = FALSE)` randomly fails")
+    array_raw <- pdftools::pdf_render_page(filename, 1L, numeric = FALSE)
+    pm <- as_bm_pixmap(array_raw)
+    expect_equal(pm[1L, 1L], col2hex("blue"))
+    bm <- as_bm_bitmap(array_raw)
+    expect_equal(bm[1L, 1L], 1L)
+})

--- a/tests/testthat/test-webp.R
+++ b/tests/testthat/test-webp.R
@@ -1,0 +1,26 @@
+test_that("`webp::read_webp()` import works", {
+    skip_if_not_installed("webp")
+
+    skip_if_not_installed("withr")
+    skip_if_not(cli::is_utf8_output())
+    withr::local_options(bm_options(default = TRUE))
+
+    filename <- tempfile(fileext = ".webp")
+    on.exit(unlink(filename))
+
+    corn <- farming_crops_16x16()$corn$portrait
+    webp::write_webp(as.array(corn), filename, quality = NA)
+
+    array_raw <- webp::read_webp(filename, numeric = FALSE)
+    array_num <- webp::read_webp(filename, numeric = TRUE)
+    pmr <- as_bm_pixmap(array_raw)
+    expect_equal(corn, pmr)
+    pmn <- as_bm_pixmap(array_num)
+    expect_equal(corn, pmn)
+
+    bm <- as_bm_bitmap(corn)
+    bmr <- as_bm_bitmap(array_raw)
+    expect_equal(bm, bmr)
+    bmn <- as_bm_bitmap(array_num)
+    expect_equal(bm, bmn)
+})


### PR DESCRIPTION
* `as_bm_bitmap.array()` / `as_bm_pixmap.array()` can now handle "raw"      arrays as returned by `pdftools::pdf_render_page(numeric = FALSE)` and `webp::read_webp(numeric = FALSE)`.
* `bm_downscale()` no longer returns invisibly.
    
closes #83
