### PR TITLE
feat(`bm_extend()`): Add mode argument supporting "constant" and "edge"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bittermelon
 Type: Package
 Title: Bitmap Tools
-Version: 2.3.0-5
+Version: 2.3.0-6
 Authors@R: c(person("Trevor L.", "Davis", role = c("aut", "cre"),
                     email = "trevor.l.davis@gmail.com",
                     comment = c(ORCID = "0000-0001-6341-4639")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ New features
 * `as_bm_pixmap()` gains a `character` method analogous to `as_bm_bitmap.character()` for rendering strings from a `bm_font()` font.
 * `read_yaff()` now supports the experimental `levels` property for greyscale fonts returning a `bm_font()` with `bm_pixmap()` glyphs. Uninked pixels are encoded as `"#FFFFFF00"` (transparent). `read_yaff()` gains a `fg` argument (default `"#000000FF"`) to control the foreground color; its RGB values are used for inked pixels and its alpha is multiplied by the level fraction to set pixel transparency.
 * `bm_bytepad()` pads bitmap widths to the nearest multiple of 8 (i.e. nearest byte) by adding pixels on the right (e.g. as required by the BDF font format) (#43).
+* `bm_extend()` gains a `mode` argument. The default `mode = "constant"` fills new pixels with `value` (existing behavior). Use `mode = "edge"` to fill new pixels by replicating the nearest edge pixel (#81).
 * `bm_extend()` gains `width_multiples_of` and `height_multiples_of` arguments that pad the bitmap's width or height to the nearest multiple of a given integer (#43).
 * `bm_rotate()` gains `in_place` and `value` arguments to rotate the glyph in place without changing the background padding (#70).
 * `bm_shift()` gains an `overflow` argument. The default `overflow = "clip"` silently clips content that would be pushed off the bitmap (matching the previous behavior). Use `overflow = "error"` to throw an error if non-padding content would be clipped, or `overflow = "wrap"` to wrap content around to the other side (#74).

--- a/R/bm_extend.R
+++ b/R/bm_extend.R
@@ -34,6 +34,8 @@
 #'              Use with the `vjust` argument to control which side receives
 #'              the extra pixels.
 #'              Cannot be combined with `sides` or `height`.
+#' @param mode Either "constant" (default) to fill new pixels with `value`,
+#'              or "edge" to fill with the nearest edge pixel.
 #' @param hjust One of "left", "center-left", "center-right", "right".
 #'              "center-left" and "center-right" will attempt to
 #'              place in "center" if possible but if not possible will bias
@@ -77,8 +79,10 @@ bm_extend <- function(
 	hjust = "center-left",
 	vjust = "center-top",
 	width_multiples_of = NULL,
-	height_multiples_of = NULL
+	height_multiples_of = NULL,
+	mode = c("constant", "edge")
 ) {
+	mode <- match.arg(mode)
 	stopifnot(missing(sides) || missing(top))
 	stopifnot(missing(sides) || missing(right))
 	stopifnot(missing(sides) || missing(bottom))
@@ -109,7 +113,8 @@ bm_extend.bm_bitmap <- function(
 	hjust = "center-left",
 	vjust = "center-top",
 	width_multiples_of = NULL,
-	height_multiples_of = NULL
+	height_multiples_of = NULL,
+	mode = c("constant", "edge")
 ) {
 	bm_extend_bitmap(
 		x,
@@ -124,7 +129,8 @@ bm_extend.bm_bitmap <- function(
 		hjust = hjust,
 		vjust = vjust,
 		width_multiples_of = width_multiples_of,
-		height_multiples_of = height_multiples_of
+		height_multiples_of = height_multiples_of,
+		mode = mode
 	)
 }
 
@@ -143,7 +149,8 @@ bm_extend.bm_pixmap <- function(
 	hjust = "center-left",
 	vjust = "center-top",
 	width_multiples_of = NULL,
-	height_multiples_of = NULL
+	height_multiples_of = NULL,
+	mode = c("constant", "edge")
 ) {
 	value <- col2hex(value)
 	bm_extend_bitmap(
@@ -159,7 +166,8 @@ bm_extend.bm_pixmap <- function(
 		hjust = hjust,
 		vjust = vjust,
 		width_multiples_of = width_multiples_of,
-		height_multiples_of = height_multiples_of
+		height_multiples_of = height_multiples_of,
+		mode = mode
 	)
 }
 
@@ -199,7 +207,8 @@ bm_extend.bm_list <- function(x, ...) {
 	hjust = "center-left",
 	vjust = "center-top",
 	width_multiples_of = NULL,
-	height_multiples_of = NULL
+	height_multiples_of = NULL,
+	mode = c("constant", "edge")
 ) {
 	stopifnot(requireNamespace("magick", quietly = TRUE))
 	pm <- `as_bm_pixmap.magick-image`(x)
@@ -217,7 +226,8 @@ bm_extend.bm_list <- function(x, ...) {
 		hjust = hjust,
 		vjust = vjust,
 		width_multiples_of = width_multiples_of,
-		height_multiples_of = height_multiples_of
+		height_multiples_of = height_multiples_of,
+		mode = mode
 	)
 	magick::image_read(pm)
 }
@@ -237,7 +247,8 @@ bm_extend.nativeRaster <- function(
 	hjust = "center-left",
 	vjust = "center-top",
 	width_multiples_of = NULL,
-	height_multiples_of = NULL
+	height_multiples_of = NULL,
+	mode = c("constant", "edge")
 ) {
 	value <- int2col(as_native(value))
 	pm <- bm_extend_bitmap(
@@ -253,7 +264,8 @@ bm_extend.nativeRaster <- function(
 		hjust = hjust,
 		vjust = vjust,
 		width_multiples_of = width_multiples_of,
-		height_multiples_of = height_multiples_of
+		height_multiples_of = height_multiples_of,
+		mode = mode
 	)
 	as.raster(pm, native = TRUE)
 }
@@ -273,7 +285,8 @@ bm_extend.raster <- function(
 	hjust = "center-left",
 	vjust = "center-top",
 	width_multiples_of = NULL,
-	height_multiples_of = NULL
+	height_multiples_of = NULL,
+	mode = c("constant", "edge")
 ) {
 	bm_extend_bitmap(
 		x,
@@ -288,7 +301,8 @@ bm_extend.raster <- function(
 		hjust = hjust,
 		vjust = vjust,
 		width_multiples_of = width_multiples_of,
-		height_multiples_of = height_multiples_of
+		height_multiples_of = height_multiples_of,
+		mode = mode
 	)
 }
 
@@ -305,8 +319,10 @@ bm_extend_bitmap <- function(
 	hjust = "center-left",
 	vjust = "center-top",
 	width_multiples_of = NULL,
-	height_multiples_of = NULL
+	height_multiples_of = NULL,
+	mode = c("constant", "edge")
 ) {
+	mode <- match.arg(mode)
 	d <- list(
 		top = top %||% 0L,
 		right = right %||% 0L,
@@ -332,89 +348,168 @@ bm_extend_bitmap <- function(
 	stopifnot(min(unlist(d)) >= 0L)
 
 	if (d$top > 0L) {
-		x <- bm_extend_helper(x, d$top, value, "top")
+		x <- bm_extend_helper(x, d$top, value, "top", mode)
 	}
 	if (d$right > 0L) {
-		x <- bm_extend_helper(x, d$right, value, "right")
+		x <- bm_extend_helper(x, d$right, value, "right", mode)
 	}
 	if (d$bottom > 0L) {
-		x <- bm_extend_helper(x, d$bottom, value, "bottom")
+		x <- bm_extend_helper(x, d$bottom, value, "bottom", mode)
 	}
 	if (d$left > 0L) {
-		x <- bm_extend_helper(x, d$left, value, "left")
+		x <- bm_extend_helper(x, d$left, value, "left", mode)
 	}
 	x
 }
 
-bm_extend_helper <- function(x, n, value, direction) {
+bm_extend_helper <- function(x, n, value, direction, mode = "constant") {
 	UseMethod("bm_extend_helper")
 }
 
 #' @export
-bm_extend_helper.bm_bitmap <- function(x, n = 1L, value = 0L, direction = "top") {
+bm_extend_helper.bm_bitmap <- function(
+	x,
+	n = 1L,
+	value = 0L,
+	direction = "top",
+	mode = c("constant", "edge")
+) {
+	mode <- match.arg(mode)
 	switch(
 		direction,
 		top = {
-			new <- as_bm_bitmap.matrix(matrix(value, nrow = n, ncol = ncol(x)))
+			new_val <- if (mode == "edge") x[nrow(x), ] else rep.int(value, ncol(x))
+			new <- as_bm_bitmap.matrix(matrix(
+				rep.int(new_val, n),
+				nrow = n,
+				ncol = ncol(x),
+				byrow = TRUE
+			))
 			rbind.bm_bitmap(new, x)
 		},
 		right = {
-			new <- as_bm_bitmap.matrix(matrix(value, nrow = nrow(x), ncol = n))
+			new_val <- if (mode == "edge") x[, ncol(x)] else rep.int(value, nrow(x))
+			new <- as_bm_bitmap.matrix(matrix(
+				rep.int(new_val, n),
+				nrow = nrow(x),
+				ncol = n
+			))
 			cbind.bm_bitmap(x, new)
 		},
 		bottom = {
-			new <- as_bm_bitmap.matrix(matrix(value, nrow = n, ncol = ncol(x)))
+			new_val <- if (mode == "edge") x[1L, ] else rep.int(value, ncol(x))
+			new <- as_bm_bitmap.matrix(matrix(
+				rep.int(new_val, n),
+				nrow = n,
+				ncol = ncol(x),
+				byrow = TRUE
+			))
 			rbind.bm_bitmap(x, new)
 		},
 		left = {
-			new <- as_bm_bitmap.matrix(matrix(value, nrow = nrow(x), ncol = n))
+			new_val <- if (mode == "edge") x[, 1L] else rep.int(value, nrow(x))
+			new <- as_bm_bitmap.matrix(matrix(
+				rep.int(new_val, n),
+				nrow = nrow(x),
+				ncol = n
+			))
 			cbind.bm_bitmap(new, x)
 		}
 	)
 }
 
 #' @export
-bm_extend_helper.bm_pixmap <- function(x, n = 1L, value = 0L, direction = "top") {
+bm_extend_helper.bm_pixmap <- function(
+	x,
+	n = 1L,
+	value = 0L,
+	direction = "top",
+	mode = c("constant", "edge")
+) {
+	mode <- match.arg(mode)
 	switch(
 		direction,
 		top = {
-			new <- as_bm_pixmap.matrix(matrix(value, nrow = n, ncol = ncol(x)))
+			new_val <- if (mode == "edge") x[nrow(x), ] else rep.int(value, ncol(x))
+			new <- as_bm_pixmap.matrix(matrix(
+				rep.int(new_val, n),
+				nrow = n,
+				ncol = ncol(x),
+				byrow = TRUE
+			))
 			rbind.bm_pixmap(new, x)
 		},
 		right = {
-			new <- as_bm_pixmap.matrix(matrix(value, nrow = nrow(x), ncol = n))
+			new_val <- if (mode == "edge") x[, ncol(x)] else rep.int(value, nrow(x))
+			new <- as_bm_pixmap.matrix(matrix(
+				rep.int(new_val, n),
+				nrow = nrow(x),
+				ncol = n
+			))
 			cbind.bm_pixmap(x, new)
 		},
 		bottom = {
-			new <- as_bm_pixmap.matrix(matrix(value, nrow = n, ncol = ncol(x)))
+			new_val <- if (mode == "edge") x[1L, ] else rep.int(value, ncol(x))
+			new <- as_bm_pixmap.matrix(matrix(
+				rep.int(new_val, n),
+				nrow = n,
+				ncol = ncol(x),
+				byrow = TRUE
+			))
 			rbind.bm_pixmap(x, new)
 		},
 		left = {
-			new <- as_bm_pixmap.matrix(matrix(value, nrow = nrow(x), ncol = n))
+			new_val <- if (mode == "edge") x[, 1L] else rep.int(value, nrow(x))
+			new <- as_bm_pixmap.matrix(matrix(
+				rep.int(new_val, n),
+				nrow = nrow(x),
+				ncol = n
+			))
 			cbind.bm_pixmap(new, x)
 		}
 	)
 }
 
 #' @export
-bm_extend_helper.raster <- function(x, n = 1L, value = "transparent", direction = "top") {
+bm_extend_helper.raster <- function(
+	x,
+	n = 1L,
+	value = "transparent",
+	direction = "top",
+	mode = c("constant", "edge")
+) {
+	mode <- match.arg(mode)
 	x <- as.matrix(x)
 	x <- switch(
 		direction,
 		top = {
-			new <- matrix(value, nrow = n, ncol = ncol(x))
+			new_val <- if (mode == "edge") x[nrow(x), ] else rep.int(value, ncol(x))
+			new <- matrix(
+				rep.int(new_val, n),
+				nrow = n,
+				ncol = ncol(x),
+				byrow = TRUE
+			)
 			rbind(new, x)
 		},
 		right = {
-			new <- matrix(value, nrow = nrow(x), ncol = n)
+			new_val <- if (mode == "edge") x[, ncol(x)] else rep.int(value, nrow(x))
+			new <- matrix(rep.int(new_val, n), nrow = nrow(x), ncol = n)
 			cbind(x, new)
 		},
 		bottom = {
-			new <- matrix(value, nrow = n, ncol = ncol(x))
+			new_val <- if (mode == "edge") x[1L, ] else rep.int(value, ncol(x))
+			new <- matrix(
+				rep.int(new_val, n),
+				nrow = n,
+				ncol = ncol(x),
+				byrow = TRUE
+			)
 			rbind(x, new)
 		},
 		left = {
-			new <- matrix(value, nrow = nrow(x), ncol = n)
+			new_val <- if (mode == "edge") x[, 1L] else rep.int(value, nrow(x))
+			new <- matrix(rep.int(new_val, n), nrow = nrow(x), ncol = n)
 			cbind(new, x)
 		}
 	)

--- a/man/bm_extend.Rd
+++ b/man/bm_extend.Rd
@@ -23,7 +23,8 @@ bm_extend(
   hjust = "center-left",
   vjust = "center-top",
   width_multiples_of = NULL,
-  height_multiples_of = NULL
+  height_multiples_of = NULL,
+  mode = c("constant", "edge")
 )
 
 \method{bm_extend}{bm_bitmap}(
@@ -39,7 +40,8 @@ bm_extend(
   hjust = "center-left",
   vjust = "center-top",
   width_multiples_of = NULL,
-  height_multiples_of = NULL
+  height_multiples_of = NULL,
+  mode = c("constant", "edge")
 )
 
 \method{bm_extend}{bm_pixmap}(
@@ -55,7 +57,8 @@ bm_extend(
   hjust = "center-left",
   vjust = "center-top",
   width_multiples_of = NULL,
-  height_multiples_of = NULL
+  height_multiples_of = NULL,
+  mode = c("constant", "edge")
 )
 
 \method{bm_extend}{bm_list}(x, ...)
@@ -73,7 +76,8 @@ bm_extend(
   hjust = "center-left",
   vjust = "center-top",
   width_multiples_of = NULL,
-  height_multiples_of = NULL
+  height_multiples_of = NULL,
+  mode = c("constant", "edge")
 )
 
 \method{bm_extend}{nativeRaster}(
@@ -89,7 +93,8 @@ bm_extend(
   hjust = "center-left",
   vjust = "center-top",
   width_multiples_of = NULL,
-  height_multiples_of = NULL
+  height_multiples_of = NULL,
+  mode = c("constant", "edge")
 )
 
 \method{bm_extend}{raster}(
@@ -105,7 +110,8 @@ bm_extend(
   hjust = "center-left",
   vjust = "center-top",
   width_multiples_of = NULL,
-  height_multiples_of = NULL
+  height_multiples_of = NULL,
+  mode = c("constant", "edge")
 )
 }
 \arguments{
@@ -163,6 +169,9 @@ equal to the current height.
 Use with the \code{vjust} argument to control which side receives
 the extra pixels.
 Cannot be combined with \code{sides} or \code{height}.}
+
+\item{mode}{Either "constant" (default) to fill new pixels with \code{value},
+or "edge" to fill with the nearest edge pixel.}
 
 \item{...}{Additional arguments to be passed to or from methods.}
 }

--- a/tests/testthat/test-bm_extend.R
+++ b/tests/testthat/test-bm_extend.R
@@ -188,6 +188,27 @@ test_that("`bm_extend.raster()`", {
 	)
 })
 
+test_that("`bm_extend()` mode = 'edge'", {
+	m <- matrix(c(1L, 2L, 3L, 4L), nrow = 2L, ncol = 2L)
+	bm <- bm_bitmap(m)
+
+	r <- bm_extend(bm, right = 2L, mode = "edge")
+	expect_equal(as.matrix(r)[1L, ], c(1L, 3L, 3L, 3L))
+	expect_equal(as.matrix(r)[2L, ], c(2L, 4L, 4L, 4L))
+
+	l <- bm_extend(bm, left = 1L, mode = "edge")
+	expect_equal(as.matrix(l)[1L, ], c(1L, 1L, 3L))
+	expect_equal(as.matrix(l)[2L, ], c(2L, 2L, 4L))
+
+	t <- bm_extend(bm, top = 2L, mode = "edge")
+	expect_equal(as.matrix(t)[1L, ], c(1L, 3L))
+	expect_equal(as.matrix(t)[4L, ], c(2L, 4L))
+
+	b <- bm_extend(bm, bottom = 1L, mode = "edge")
+	expect_equal(as.matrix(b)[1L, ], c(1L, 3L))
+	expect_equal(as.matrix(b)[2L, ], c(1L, 3L))
+})
+
 test_that("`bm_extend.nativeRaster()`", {
 	skip_if_not_installed("farver")
 	skip_if_not_installed("withr")


### PR DESCRIPTION
* `bm_extend()` gains a `mode` argument. The default `mode = "constant"` fills new pixels with `value` (existing behavior). Use `mode = "edge"` to fill new pixels by replicating the nearest edge pixel (#81).